### PR TITLE
리프레시 토큰을 사용한 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/com/example/tennismate/global/constants/AuthEndPoints.java
+++ b/src/main/java/com/example/tennismate/global/constants/AuthEndPoints.java
@@ -1,0 +1,20 @@
+package com.example.tennismate.global.constants;
+
+public final class AuthEndPoints {
+    // private 생성자로 객체 생성 막음
+    private AuthEndPoints() {
+    }
+
+    public static final String[] SWAGGER_ENDPOINTS = {
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/swagger-resources/**",
+            "/webjars/**"
+    };
+
+    public static final String[] AUTH_PERMIT_ENDPOINTS = {
+            "/api/v1/members/signup",
+            "/api/v1/members/login",
+            "/api/v1/members/refresh"
+    };
+}

--- a/src/main/java/com/example/tennismate/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/example/tennismate/infrastructure/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.tennismate.infrastructure.config;
 import com.example.tennismate.infrastructure.security.filter.CustomLoginFilter;
 import com.example.tennismate.infrastructure.security.filter.JwtAuthorizationFilter;
 import com.example.tennismate.infrastructure.security.jwt.JwtProvider;
+import com.example.tennismate.member.application.port.MemberRepositoryPort;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -28,6 +29,7 @@ public class SecurityConfig {
     private final ObjectMapper objectMapper;
     private final AuthenticationConfiguration authenticationConfiguration;
     private final UserDetailsService userDetailsService;
+    private final MemberRepositoryPort memberRepositoryPort;
 
     private static final String[] SWAGGER_WHITELIST = {
             "/swagger-ui/**",
@@ -48,7 +50,7 @@ public class SecurityConfig {
 
     @Bean
     public CustomLoginFilter customLoginFilter() throws Exception {
-        CustomLoginFilter customLoginFilter = new CustomLoginFilter(jwtProvider, objectMapper);
+        CustomLoginFilter customLoginFilter = new CustomLoginFilter(jwtProvider, objectMapper, memberRepositoryPort);
         customLoginFilter.setAuthenticationManager(authenticationManager());
         return customLoginFilter;
     }

--- a/src/main/java/com/example/tennismate/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/example/tennismate/infrastructure/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.tennismate.infrastructure.config;
 
+import com.example.tennismate.global.constants.AuthEndPoints;
 import com.example.tennismate.infrastructure.security.filter.CustomLoginFilter;
 import com.example.tennismate.infrastructure.security.filter.JwtAuthorizationFilter;
 import com.example.tennismate.infrastructure.security.jwt.JwtProvider;
@@ -30,13 +31,6 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final UserDetailsService userDetailsService;
     private final MemberRepositoryPort memberRepositoryPort;
-
-    private static final String[] SWAGGER_WHITELIST = {
-            "/swagger-ui/**",
-            "/v3/api-docs/**",
-            "/swagger-resources/**",
-            "/webjars/**"
-    };
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -72,9 +66,9 @@ public class SecurityConfig {
 
         // URL 별 경로 권한 설정
         http.authorizeHttpRequests(authorize -> authorize
-                .requestMatchers(SWAGGER_WHITELIST).permitAll()
+                .requestMatchers(AuthEndPoints.SWAGGER_ENDPOINTS).permitAll()
                 // 회원가입, 로그인 경로 오픈
-                .requestMatchers(HttpMethod.POST, "/api/v1/members/signup", "/api/v1/members/login").permitAll()
+                .requestMatchers(HttpMethod.POST, AuthEndPoints.AUTH_PERMIT_ENDPOINTS).permitAll()
                 .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/example/tennismate/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/example/tennismate/infrastructure/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package com.example.tennismate.infrastructure.config;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,7 +21,8 @@ public class SwaggerConfig {
                 // 1. SecurityScheme 이름 정의
                 String jwtSchemeName = "jwtAuth";
 
-                // TODO : 2. API 요청 헤더에 인증 정보 포함을 위한 SecurityRequirement 객체 생성
+                // 2. API 요청 헤더에 인증 정보 포함을 위한 SecurityRequirement 객체 생성
+                SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
 
                 // TODO : 3. SecuritySchemes 객체 설정
 

--- a/src/main/java/com/example/tennismate/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/example/tennismate/infrastructure/config/SwaggerConfig.java
@@ -2,8 +2,10 @@ package com.example.tennismate.infrastructure.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,7 +26,17 @@ public class SwaggerConfig {
                 // 2. API 요청 헤더에 인증 정보 포함을 위한 SecurityRequirement 객체 생성
                 SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
 
-                // TODO : 3. SecuritySchemes 객체 설정
+                // 3. SecuritySchemes 객체 설정
+                Components components = new Components()
+                        .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                                .name(jwtSchemeName)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                        );
 
+                return new OpenAPI()
+                        .addSecurityItem(securityRequirement)
+                        .components(components);
         }
 }

--- a/src/main/java/com/example/tennismate/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/example/tennismate/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,27 @@
+package com.example.tennismate.infrastructure.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "TennisMate API 명세서",
+                description = "테니스메이트 프로젝트 API 명세서 입니다.",
+                version = "v1"
+        )
+)
+@Configuration
+public class SwaggerConfig {
+        @Bean
+        public OpenAPI openAPI() {
+                // TODO : 1. SecurityScheme 이름 정의
+
+                // TODO : 2. API 요청 헤더에 인증 정보 포함을 위한 SecurityRequirement 객체 생성
+
+                // TODO : 3. SecuritySchemes 객체 설정
+
+        }
+}

--- a/src/main/java/com/example/tennismate/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/example/tennismate/infrastructure/config/SwaggerConfig.java
@@ -17,7 +17,8 @@ import org.springframework.context.annotation.Configuration;
 public class SwaggerConfig {
         @Bean
         public OpenAPI openAPI() {
-                // TODO : 1. SecurityScheme 이름 정의
+                // 1. SecurityScheme 이름 정의
+                String jwtSchemeName = "jwtAuth";
 
                 // TODO : 2. API 요청 헤더에 인증 정보 포함을 위한 SecurityRequirement 객체 생성
 

--- a/src/main/java/com/example/tennismate/infrastructure/exception/custom/InvalidTokenException.java
+++ b/src/main/java/com/example/tennismate/infrastructure/exception/custom/InvalidTokenException.java
@@ -1,0 +1,14 @@
+package com.example.tennismate.infrastructure.exception.custom;
+
+import com.example.tennismate.infrastructure.exception.errorcode.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class InvalidTokenException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public InvalidTokenException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/tennismate/infrastructure/exception/custom/NotFoundException.java
+++ b/src/main/java/com/example/tennismate/infrastructure/exception/custom/NotFoundException.java
@@ -1,0 +1,13 @@
+package com.example.tennismate.infrastructure.exception.custom;
+
+import com.example.tennismate.infrastructure.exception.errorcode.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class NotFoundException extends RuntimeException {
+    private final ErrorCode errorCode;
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/tennismate/infrastructure/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/example/tennismate/infrastructure/exception/errorcode/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
 
     // token
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+    MISMATCHED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token 이 일치하지 않습니다.");
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/tennismate/infrastructure/exception/errorcode/ErrorCode.java
+++ b/src/main/java/com/example/tennismate/infrastructure/exception/errorcode/ErrorCode.java
@@ -7,7 +7,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     // member
     DUPLICATED_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
-    DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임 입니다.")
+    DUPLICATED_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임 입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    // token
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/tennismate/infrastructure/exception/handler/InvalidExceptionHandler.java
+++ b/src/main/java/com/example/tennismate/infrastructure/exception/handler/InvalidExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.example.tennismate.infrastructure.exception.handler;
+
+import com.example.tennismate.global.response.ApiResponse;
+import com.example.tennismate.infrastructure.exception.custom.InvalidTokenException;
+import com.example.tennismate.infrastructure.exception.custom.NotFoundException;
+import com.example.tennismate.infrastructure.exception.errorcode.ErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class InvalidExceptionHandler {
+    @ExceptionHandler(value = InvalidTokenException.class)
+    public ResponseEntity<ApiResponse<?>> invalidTokenExceptionHandler(InvalidTokenException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode.getStatus().value(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(value = NotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> notFoundExceptionHandler(NotFoundException exception) {
+        ErrorCode errorCode = exception.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.error(errorCode.getStatus().value(), errorCode.getMessage()));
+    }
+}

--- a/src/main/java/com/example/tennismate/infrastructure/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/example/tennismate/infrastructure/security/filter/CustomLoginFilter.java
@@ -74,7 +74,7 @@ public class CustomLoginFilter extends AbstractAuthenticationProcessingFilter {
 
         // 3. Jwt Provider 를 사용해 토큰 생성 (Access Token 에 id 포함)
         String accessToken = jwtProvider.createAccessToken(id, email, role);
-        String refreshToken = jwtProvider.createRefreshToken();
+        String refreshToken = jwtProvider.createRefreshToken(id);
 
         // 4. 실제 데이터를 담아 응답 DTO 생성
         MemberLoginResponse loginResponse = MemberLoginResponse.of(email, nickname, role, accessToken, refreshToken);

--- a/src/main/java/com/example/tennismate/infrastructure/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/example/tennismate/infrastructure/security/filter/CustomLoginFilter.java
@@ -32,7 +32,7 @@ public class CustomLoginFilter extends AbstractAuthenticationProcessingFilter {
 
     // 1. 생성자
     public CustomLoginFilter(JwtProvider jwtProvider, ObjectMapper objectMapper, MemberRepositoryPort memberRepositoryPort) {
-        // 2. 부모 클래서 생성자 호출
+        // 2. 부모 클래스 생성자 호출
         // 로그인 URI 에 대한 요청을 가로챌 수 있도록 설정
         super(new AntPathRequestMatcher("/api/v1/members/login", "POST"));
         this.jwtProvider = jwtProvider;

--- a/src/main/java/com/example/tennismate/infrastructure/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/example/tennismate/infrastructure/security/filter/CustomLoginFilter.java
@@ -3,8 +3,10 @@ package com.example.tennismate.infrastructure.security.filter;
 import com.example.tennismate.global.response.ApiResponse;
 import com.example.tennismate.infrastructure.security.domain.CustomUserDetails;
 import com.example.tennismate.infrastructure.security.jwt.JwtProvider;
+import com.example.tennismate.member.application.port.MemberRepositoryPort;
 import com.example.tennismate.member.dto.request.MemberLoginRequest;
 import com.example.tennismate.member.dto.response.MemberLoginResponse;
+import com.example.tennismate.member.entity.Member;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -26,14 +28,16 @@ import java.io.IOException;
 public class CustomLoginFilter extends AbstractAuthenticationProcessingFilter {
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
+    private final MemberRepositoryPort memberRepositoryPort;
 
     // 1. 생성자
-    public CustomLoginFilter(JwtProvider jwtProvider, ObjectMapper objectMapper) {
+    public CustomLoginFilter(JwtProvider jwtProvider, ObjectMapper objectMapper, MemberRepositoryPort memberRepositoryPort) {
         // 2. 부모 클래서 생성자 호출
         // 로그인 URI 에 대한 요청을 가로챌 수 있도록 설정
         super(new AntPathRequestMatcher("/api/v1/members/login", "POST"));
         this.jwtProvider = jwtProvider;
         this.objectMapper = objectMapper;
+        this.memberRepositoryPort = memberRepositoryPort;
     }
 
     @Override
@@ -75,6 +79,14 @@ public class CustomLoginFilter extends AbstractAuthenticationProcessingFilter {
         // 3. Jwt Provider 를 사용해 토큰 생성 (Access Token 에 id 포함)
         String accessToken = jwtProvider.createAccessToken(id, email, role);
         String refreshToken = jwtProvider.createRefreshToken(email);
+
+        // 3-1. DB 에서 사용자 정보 조회
+        Member member = memberRepositoryPort.findMemberByEmail(email)
+                .orElseThrow(() -> new ServletException("Could not find member"));
+
+        // 3-2. dirty checking 또는 명시적 save 를 위해 Refresh Token 업데이트
+        member.updateRefreshToken(refreshToken);
+        memberRepositoryPort.save(member);
 
         // 4. 실제 데이터를 담아 응답 DTO 생성
         MemberLoginResponse loginResponse = MemberLoginResponse.of(email, nickname, role, accessToken, refreshToken);

--- a/src/main/java/com/example/tennismate/infrastructure/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/example/tennismate/infrastructure/security/filter/CustomLoginFilter.java
@@ -74,7 +74,7 @@ public class CustomLoginFilter extends AbstractAuthenticationProcessingFilter {
 
         // 3. Jwt Provider 를 사용해 토큰 생성 (Access Token 에 id 포함)
         String accessToken = jwtProvider.createAccessToken(id, email, role);
-        String refreshToken = jwtProvider.createRefreshToken(id);
+        String refreshToken = jwtProvider.createRefreshToken(email);
 
         // 4. 실제 데이터를 담아 응답 DTO 생성
         MemberLoginResponse loginResponse = MemberLoginResponse.of(email, nickname, role, accessToken, refreshToken);

--- a/src/main/java/com/example/tennismate/infrastructure/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/example/tennismate/infrastructure/security/filter/JwtAuthorizationFilter.java
@@ -30,7 +30,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         // 1. 요청 헤더에서 토큰 추출
-        String token = resolveToken(request);
+        String token = jwtProvider.resolveToken(request);
 
         // 2. 토큰 유효성 검증
         if (StringUtils.hasText(token) && jwtProvider.validateToken(token)) {
@@ -72,18 +72,4 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    /**
-     * 요청 헤더에서 "Bearer " 접두사를 제거하고 순수 토큰을 반환하는 메서드
-     * @param request : 요청 헤더
-     * @return : 순수 토큰 or null 반환
-     */
-    private String resolveToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-
-        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-
-        return null;
-    }
 }

--- a/src/main/java/com/example/tennismate/infrastructure/security/jwt/JwtProvider.java
+++ b/src/main/java/com/example/tennismate/infrastructure/security/jwt/JwtProvider.java
@@ -3,6 +3,7 @@ package com.example.tennismate.infrastructure.security.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SecurityException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -110,4 +111,7 @@ public class JwtProvider {
         return jwtParser.parseSignedClaims(token).getPayload().get("email", String.class);
     }
 
+    public String resolveRefreshToken(HttpServletRequest request) {
+        return null;
+    }
 }

--- a/src/main/java/com/example/tennismate/infrastructure/security/jwt/JwtProvider.java
+++ b/src/main/java/com/example/tennismate/infrastructure/security/jwt/JwtProvider.java
@@ -56,13 +56,15 @@ public class JwtProvider {
 
     /**
      * Refresh Token 생성
+     * @param id : 회원 ID 값
      * @return : Refresh Token
      */
-    public String createRefreshToken() {
+    public String createRefreshToken(Long id) {
         long now = System.currentTimeMillis();
         Date refreshTokenExpiresIn = new Date(now + this.refreshTokenExpirationMs);
 
         return Jwts.builder()
+                .claims(Map.of("id", id))
                 .expiration(refreshTokenExpiresIn)
                 .signWith(secretKey)
                 .compact();
@@ -98,4 +100,14 @@ public class JwtProvider {
         // 미리 만들어둔 파서를 사용하여 토큰의 내용의 내용물인 Claims(payload) 를 추출
         return jwtParser.parseSignedClaims(token).getPayload();
     }
+
+    /**
+     * 토큰에서 사용자 ID 값 추출하는 메서드
+     * @param token : JWT 토큰
+     * @return : 사용자 ID 값 반환
+     */
+    public Long getUserIdFromToken(String token) {
+        return jwtParser.parseSignedClaims(token).getPayload().get("id", Long.class);
+    }
+
 }

--- a/src/main/java/com/example/tennismate/infrastructure/security/jwt/JwtProvider.java
+++ b/src/main/java/com/example/tennismate/infrastructure/security/jwt/JwtProvider.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
@@ -111,7 +112,18 @@ public class JwtProvider {
         return jwtParser.parseSignedClaims(token).getPayload().get("email", String.class);
     }
 
+    /**
+     * 요청 헤더에서 리프레시 토큰을 반환하는 메서드
+     * @param request : 요청 헤더
+     * @return : refresh token 또는 null 반환
+     */
     public String resolveRefreshToken(HttpServletRequest request) {
+        String refreshToken = request.getHeader("Refresh-Token");
+
+        if (StringUtils.hasText(refreshToken)) {
+            return refreshToken;
+        }
+
         return null;
     }
 }

--- a/src/main/java/com/example/tennismate/infrastructure/security/jwt/JwtProvider.java
+++ b/src/main/java/com/example/tennismate/infrastructure/security/jwt/JwtProvider.java
@@ -113,6 +113,21 @@ public class JwtProvider {
     }
 
     /**
+     * 요청 헤더에서 "Bearer " 접두사를 제거하고 순수 토큰을 반환하는 메서드
+     * @param request : 요청 헤더
+     * @return : 순수 토큰 or null 반환
+     */
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+
+        return null;
+    }
+
+    /**
      * 요청 헤더에서 리프레시 토큰을 반환하는 메서드
      * @param request : 요청 헤더
      * @return : refresh token 또는 null 반환

--- a/src/main/java/com/example/tennismate/infrastructure/security/jwt/JwtProvider.java
+++ b/src/main/java/com/example/tennismate/infrastructure/security/jwt/JwtProvider.java
@@ -56,15 +56,15 @@ public class JwtProvider {
 
     /**
      * Refresh Token 생성
-     * @param id : 회원 ID 값
+     * @param email : 회원 ID 값
      * @return : Refresh Token
      */
-    public String createRefreshToken(Long id) {
+    public String createRefreshToken(String email) {
         long now = System.currentTimeMillis();
         Date refreshTokenExpiresIn = new Date(now + this.refreshTokenExpirationMs);
 
         return Jwts.builder()
-                .claims(Map.of("id", id))
+                .claims(Map.of("email", email))
                 .expiration(refreshTokenExpiresIn)
                 .signWith(secretKey)
                 .compact();
@@ -102,12 +102,12 @@ public class JwtProvider {
     }
 
     /**
-     * 토큰에서 사용자 ID 값 추출하는 메서드
+     * 토큰에서 사용자 이메일 값 추출하는 메서드
      * @param token : JWT 토큰
-     * @return : 사용자 ID 값 반환
+     * @return : 사용자 이메일 값 반환
      */
-    public Long getUserIdFromToken(String token) {
-        return jwtParser.parseSignedClaims(token).getPayload().get("id", Long.class);
+    public String getUserEmailFromToken(String token) {
+        return jwtParser.parseSignedClaims(token).getPayload().get("email", String.class);
     }
 
 }

--- a/src/main/java/com/example/tennismate/member/application/port/MemberRepositoryPort.java
+++ b/src/main/java/com/example/tennismate/member/application/port/MemberRepositoryPort.java
@@ -5,6 +5,10 @@ import com.example.tennismate.member.entity.Member;
 import java.util.Optional;
 
 public interface MemberRepositoryPort {
+    /**
+     * 새로운 Member 를 등록(가입) 할 때 사용하는 메서드
+     * @param member : 신규 Member 객체
+     */
     void register(Member member);
 
     boolean existsByEmail(String email);
@@ -12,4 +16,10 @@ public interface MemberRepositoryPort {
     boolean existsByNickname(String nickname);
 
     Optional<Member> findMemberByEmail(String email);
+
+    /**
+     * Member 객체를 저장하거나 업데이트 시 사용하는 메서드
+     * @param member : create, update 할 Member 객체
+     */
+    void save(Member member);
 }

--- a/src/main/java/com/example/tennismate/member/application/service/MemberService.java
+++ b/src/main/java/com/example/tennismate/member/application/service/MemberService.java
@@ -1,7 +1,10 @@
 package com.example.tennismate.member.application.service;
 
 import com.example.tennismate.member.dto.request.MemberRegisterRequest;
+import com.example.tennismate.member.dto.response.TokenResponse;
 
 public interface MemberService {
     void register(MemberRegisterRequest memberRegisterRequest);
+
+    TokenResponse reissueToken(String refreshToken);
 }

--- a/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
@@ -1,15 +1,15 @@
 package com.example.tennismate.member.application.service.impl;
 
-import com.example.tennismate.infrastructure.exception.custom.InvalidTokenException;
-import com.example.tennismate.infrastructure.security.jwt.JwtProvider;
-import com.example.tennismate.member.dto.response.TokenResponse;
-import com.example.tennismate.member.enums.MemberRole;
 import com.example.tennismate.infrastructure.exception.custom.DuplicatedException;
+import com.example.tennismate.infrastructure.exception.custom.InvalidTokenException;
 import com.example.tennismate.infrastructure.exception.errorcode.ErrorCode;
+import com.example.tennismate.infrastructure.security.jwt.JwtProvider;
 import com.example.tennismate.member.application.port.MemberRepositoryPort;
 import com.example.tennismate.member.application.service.MemberService;
 import com.example.tennismate.member.dto.request.MemberRegisterRequest;
+import com.example.tennismate.member.dto.response.TokenResponse;
 import com.example.tennismate.member.entity.Member;
+import com.example.tennismate.member.enums.MemberRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -48,7 +48,8 @@ public class MemberServiceImpl implements MemberService {
             throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
         }
 
-        // TODO : 2. Refresh Token 에서 이메일 추출
+        // 2. Refresh Token 에서 이메일 추출
+        String email = jwtProvider.getUserInfoFromToken(refreshToken).get("email", String.class);
 
         // TODO : 3. DB 에 저장된 Refresh Token 과 일치하는지 확인
 

--- a/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
@@ -31,7 +31,7 @@ public class MemberServiceImpl implements MemberService {
         String encodedPassword = passwordEncoder.encode(memberRegisterRequest.password());
 
         // member 객체 생성
-        Member member = Member.of(memberRegisterRequest.email(), encodedPassword, memberRegisterRequest.nickname(), memberRegisterRequest.phoneNumber(), memberRegisterRequest.age(), null, null, MemberRole.ROLE_USER);
+        Member member = Member.of(memberRegisterRequest.email(), encodedPassword, memberRegisterRequest.nickname(), memberRegisterRequest.phoneNumber(), memberRegisterRequest.age(), null, null, null, MemberRole.ROLE_USER);
 
         // member save
         memberRepository.register(member);

--- a/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.tennismate.member.application.service.impl;
 
 import com.example.tennismate.infrastructure.exception.custom.DuplicatedException;
 import com.example.tennismate.infrastructure.exception.custom.InvalidTokenException;
+import com.example.tennismate.infrastructure.exception.custom.NotFoundException;
 import com.example.tennismate.infrastructure.exception.errorcode.ErrorCode;
 import com.example.tennismate.infrastructure.security.jwt.JwtProvider;
 import com.example.tennismate.member.application.port.MemberRepositoryPort;
@@ -51,7 +52,12 @@ public class MemberServiceImpl implements MemberService {
         // 2. Refresh Token 에서 이메일 추출
         String email = jwtProvider.getUserInfoFromToken(refreshToken).get("email", String.class);
 
-        // TODO : 3. DB 에 저장된 Refresh Token 과 일치하는지 확인
+        // 3. DB 에 저장된 Refresh Token 과 일치하는지 확인
+        Member member = memberRepository.findMemberByEmail(email).orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (!member.getRefreshToken().equals(refreshToken)) {
+            throw new InvalidTokenException(ErrorCode.MISMATCHED_REFRESH_TOKEN);
+        }
 
         // TODO : 4. 새로운 Access Token 생성
 

--- a/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package com.example.tennismate.member.application.service.impl;
 
+import com.example.tennismate.member.dto.response.TokenResponse;
 import com.example.tennismate.member.enums.MemberRole;
 import com.example.tennismate.infrastructure.exception.custom.DuplicatedException;
 import com.example.tennismate.infrastructure.exception.errorcode.ErrorCode;
@@ -35,6 +36,11 @@ public class MemberServiceImpl implements MemberService {
 
         // member save
         memberRepository.register(member);
+    }
+
+    @Override
+    public TokenResponse reissueToken(String refreshToken) {
+        return null;
     }
 
     /**

--- a/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
@@ -43,6 +43,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public TokenResponse reissueToken(String refreshToken) {
         // 1. Refresh Token 유효성 검증
         if (jwtProvider.validateToken(refreshToken)) {
@@ -59,11 +60,12 @@ public class MemberServiceImpl implements MemberService {
             throw new InvalidTokenException(ErrorCode.MISMATCHED_REFRESH_TOKEN);
         }
 
-        // TODO : 4. 새로운 Access Token 생성
+        // 4. 새로운 토큰 생성 및 저장
+        String newAccessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail(), member.getRole().name());
+        String newRefreshToken = jwtProvider.createRefreshToken(member.getEmail());
+        member.updateRefreshToken(newRefreshToken);
 
-        // TODO : 5. 새로운 Refresh Token 생성 후 DB 저장
-
-        return null;
+        return TokenResponse.of(newAccessToken, newRefreshToken);
     }
 
     /**

--- a/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/tennismate/member/application/service/impl/MemberServiceImpl.java
@@ -1,5 +1,7 @@
 package com.example.tennismate.member.application.service.impl;
 
+import com.example.tennismate.infrastructure.exception.custom.InvalidTokenException;
+import com.example.tennismate.infrastructure.security.jwt.JwtProvider;
 import com.example.tennismate.member.dto.response.TokenResponse;
 import com.example.tennismate.member.enums.MemberRole;
 import com.example.tennismate.infrastructure.exception.custom.DuplicatedException;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberServiceImpl implements MemberService {
     private final MemberRepositoryPort memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
 
     @Override
     @Transactional
@@ -40,6 +43,19 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public TokenResponse reissueToken(String refreshToken) {
+        // 1. Refresh Token 유효성 검증
+        if (jwtProvider.validateToken(refreshToken)) {
+            throw new InvalidTokenException(ErrorCode.INVALID_TOKEN);
+        }
+
+        // TODO : 2. Refresh Token 에서 이메일 추출
+
+        // TODO : 3. DB 에 저장된 Refresh Token 과 일치하는지 확인
+
+        // TODO : 4. 새로운 Access Token 생성
+
+        // TODO : 5. 새로운 Refresh Token 생성 후 DB 저장
+
         return null;
     }
 

--- a/src/main/java/com/example/tennismate/member/controller/MemberController.java
+++ b/src/main/java/com/example/tennismate/member/controller/MemberController.java
@@ -42,7 +42,7 @@ public class MemberController {
 
 
         return ResponseEntity.ok(
-                ApiResponse.ok("토큰이 정상적으로 발급되었습니다.")
+                ApiResponse.ok("토큰이 정상적으로 발급되었습니다.", tokenResponse)
         );
     }
 }

--- a/src/main/java/com/example/tennismate/member/controller/MemberController.java
+++ b/src/main/java/com/example/tennismate/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.example.tennismate.member.controller;
 import com.example.tennismate.global.response.ApiResponse;
 import com.example.tennismate.member.application.service.MemberService;
 import com.example.tennismate.member.dto.request.MemberRegisterRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,18 @@ public class MemberController {
 
         return ResponseEntity.ok(
                 ApiResponse.ok("회원가입이 완료되었습니다.")
+        );
+    }
+
+    @PostMapping(path = "/refresh")
+    public ResponseEntity<ApiResponse<?>> refresh(HttpServletRequest request) {
+        // TODO : 1. 요청 헤더에서 Refresh Token 추출
+
+        // TODO : 2. 서비스를 호출하여 새로운 토큰 발급
+
+
+        return ResponseEntity.ok(
+                ApiResponse.ok("토큰이 정상적으로 발급되었습니다.")
         );
     }
 }

--- a/src/main/java/com/example/tennismate/member/controller/MemberController.java
+++ b/src/main/java/com/example/tennismate/member/controller/MemberController.java
@@ -1,8 +1,10 @@
 package com.example.tennismate.member.controller;
 
 import com.example.tennismate.global.response.ApiResponse;
+import com.example.tennismate.infrastructure.security.jwt.JwtProvider;
 import com.example.tennismate.member.application.service.MemberService;
 import com.example.tennismate.member.dto.request.MemberRegisterRequest;
+import com.example.tennismate.member.dto.response.TokenResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(path = "/api/v1/members")
 public class MemberController {
     private final MemberService memberService;
+    private final JwtProvider jwtProvider;
 
     @PostMapping(path = "/signup")
     public ResponseEntity<ApiResponse<?>> register(
@@ -31,9 +34,11 @@ public class MemberController {
 
     @PostMapping(path = "/refresh")
     public ResponseEntity<ApiResponse<?>> refresh(HttpServletRequest request) {
-        // TODO : 1. 요청 헤더에서 Refresh Token 추출
+        // 1. 요청 헤더에서 Refresh Token 추출
+        String refreshToken = jwtProvider.resolveRefreshToken(request);
 
-        // TODO : 2. 서비스를 호출하여 새로운 토큰 발급
+        // 2. 서비스를 호출하여 새로운 토큰 발급
+        TokenResponse tokenResponse = memberService.reissueToken(refreshToken);
 
 
         return ResponseEntity.ok(

--- a/src/main/java/com/example/tennismate/member/dto/response/TokenResponse.java
+++ b/src/main/java/com/example/tennismate/member/dto/response/TokenResponse.java
@@ -1,0 +1,4 @@
+package com.example.tennismate.member.dto.response;
+
+public record TokenResponse() {
+}

--- a/src/main/java/com/example/tennismate/member/dto/response/TokenResponse.java
+++ b/src/main/java/com/example/tennismate/member/dto/response/TokenResponse.java
@@ -1,4 +1,10 @@
 package com.example.tennismate.member.dto.response;
 
-public record TokenResponse() {
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
 }

--- a/src/main/java/com/example/tennismate/member/entity/Member.java
+++ b/src/main/java/com/example/tennismate/member/entity/Member.java
@@ -35,11 +35,35 @@ public class Member extends BaseEntity {
     @Column(name = "cover_image_url", columnDefinition = "TEXT")
     private String coverImageUrl;
 
+    @Column(name = "refresh_token", columnDefinition = "TEXT")
+    private String refreshToken;
+
     @Column(name = "role", nullable = false)
     @Enumerated(value = EnumType.STRING)
     private MemberRole role;
 
-    public static Member of(String email, String password, String nickname, String phoneNumber, Integer age, String profileImageUrl, String coverImageUrl, MemberRole role) {
-        return new Member(email, password, nickname, phoneNumber, age, profileImageUrl, coverImageUrl, role);
+    /**
+     * refresh Token 을 쉽게 업데이트하기 위한 비즈니스 메서드
+     * @param refreshToken : 리프레시 토큰
+     */
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    /**
+     * Member 객체 생성을 위한 of 메서드
+     * @param email : 사용자 이메일 ID
+     * @param password : 패스워드
+     * @param nickname : 닉네임
+     * @param phoneNumber : 휴대폰 번호
+     * @param age : 나이
+     * @param profileImageUrl : 프로필 이미지 url
+     * @param coverImageUrl : 커버 이미지 url
+     * @param refreshToken : 리프레시 토큰
+     * @param role : 사용자 권한
+     * @return : Member 객체
+     */
+    public static Member of(String email, String password, String nickname, String phoneNumber, Integer age, String profileImageUrl, String coverImageUrl, String refreshToken, MemberRole role) {
+        return new Member(email, password, nickname, phoneNumber, age, profileImageUrl, coverImageUrl, refreshToken, role);
     }
 }

--- a/src/main/java/com/example/tennismate/member/repository/adapter/MemberRepositoryAdapter.java
+++ b/src/main/java/com/example/tennismate/member/repository/adapter/MemberRepositoryAdapter.java
@@ -34,4 +34,9 @@ public class MemberRepositoryAdapter implements MemberRepositoryPort {
     public Optional<Member> findMemberByEmail(String email) {
         return memberRepository.findByEmail(email);
     }
+
+    @Override
+    public void save(Member member) {
+        memberRepository.save(member);
+    }
 }


### PR DESCRIPTION
access token의 유효기간이 만료되었을 때, refresh token을 사용하여 재발급 해주는 로직을 구현 완료.

* 리프레시 토큰의 정보를 검증.
* 일치하면 새로운 토큰 발급, 불일치하면 에러 처리.

This closes #16 